### PR TITLE
Updated elasticMQ version and added BIND_PORT environment var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM       openjdk:8u111-jre
 MAINTAINER Colin Vipurs (zodiaczx6@gmail.com)
 
-ADD  https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.11.1.jar /elasticmq/elasticmq.jar
+ADD  https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar /elasticmq/elasticmq.jar
 ADD  run /elasticmq/run
 RUN  chmod +x /elasticmq/run
 

--- a/run
+++ b/run
@@ -11,6 +11,10 @@ if [ -z "$NODE_PORT" ]; then
 	NODE_PORT="9324"
 fi
 
+if [ -z "$BIND_PORT" ]; then
+	BIND_PORT="9324"
+fi
+
 CONFIG=$(cat <<EOF
 // https://github.com/adamw/elasticmq#installation-stand-alone
 include classpath("application.conf")
@@ -27,7 +31,7 @@ node-address {
 
 rest-sqs {
     enabled = true
-    bind-port = 9324
+    bind-port = $BIND_PORT
     bind-hostname = "0.0.0.0"
     // Possible values: relaxed, strict
     sqs-limits = strict


### PR DESCRIPTION
Gives the ability to use the `*` wildcard in the `NODE_HOST` configuration and change the SQS rest server port