### PR TITLE
update elastic mq version and jdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM       openjdk:8u111-jre
+FROM       openjdk:8u252-jre
 MAINTAINER Colin Vipurs (zodiaczx6@gmail.com)
 
-ADD  https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar /elasticmq/elasticmq.jar
+ADD  https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.7.jar /elasticmq/elasticmq.jar
 ADD  run /elasticmq/run
 RUN  chmod +x /elasticmq/run
 


### PR DESCRIPTION
existing jdk version is trying to use deprecated jessie
newer elastic mq version has RedrivePolicy attributes available